### PR TITLE
Remove set_defaults from parent ArgumentParser

### DIFF
--- a/src/mergerfs.ctl
+++ b/src/mergerfs.ctl
@@ -112,7 +112,6 @@ def print_mergerfs_info(fspaths):
 def build_arg_parser():
     desc = 'a tool for runtime manipulation of mergerfs'
     parser = argparse.ArgumentParser(description=desc)
-    parser.set_defaults(func=None)
 
     subparsers = parser.add_subparsers(dest='command')
 

--- a/src/mergerfs.ctl
+++ b/src/mergerfs.ctl
@@ -260,7 +260,7 @@ def main():
     elif args.mount and args.mount not in fspaths:
         print_and_exit('{0} is not a mergerfs mount'.format(args.mount),1)
 
-    if args.func:
+    if hasattr(args, 'func'):
         args.func(fspaths,args)
     else:
         parser.print_help()


### PR DESCRIPTION
On older versions of Python3, defaults set on the parent ArgumentParser were not overridden by subparsers, leading to a scenario where `func` was always `None` and thus no commands in `mergerfs.ctl` were operational.

Here's a link to the Python bug report: https://bugs.python.org/issue9351.  It's unclear to me what versions received the patch in that issue, and it's still open because apparently that patch broke other things.  However, I am able to confirm that the bug exists in the default Python3 version in Debian 8, `3.4.2`.

Removing the parent `set_defaults` line seems to fix all the issues with no downsides.