### PR TITLE
explicitly specify python2's usage for fsck

### DIFF
--- a/src/mergerfs.fsck
+++ b/src/mergerfs.fsck
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
 
@@ -66,7 +66,7 @@ def print_stats(Files,Stats):
             Stats[i].st_mode,
             Stats[i].st_size,
             Stats[i].st_mtime)
-        print data
+        print (data)
 
 
 def noop_fix(paths,stats):


### PR DESCRIPTION
Specifying python version explicitly fixes syntax issue when python3 is default.