### PR TITLE
Update --help output to state default dedup strategy (newest)

### DIFF
--- a/src/mergerfs.dedup
+++ b/src/mergerfs.dedup
@@ -272,7 +272,7 @@ def buildargparser():
     parser.add_argument('-d','--dedup',
                         choices=['manual','newest','largest','mostfreespace'],
                         default='newest',
-                        help='what file to **keep**')
+                        help='what file to **keep**, default newest')
     parser.add_argument('-e','--execute',
                         action='store_true',
                         help='without this it will dryrun')


### PR DESCRIPTION
Users should not need to consult the config files (*.c) and help files (*.h) :-)