### PR TITLE
Do not implicitly ignore other IOErrors

### DIFF
--- a/src/mergerfs.dedup
+++ b/src/mergerfs.dedup
@@ -526,6 +526,8 @@ def main():
     except IOError as e:
         if e.errno == errno.EPIPE:
             pass
+        else:
+            raise
 
     print('# Total savings:',sizeof_fmt(total_size))
 

--- a/src/mergerfs.fsck
+++ b/src/mergerfs.fsck
@@ -205,6 +205,8 @@ def main():
     except IOError as e:
         if e.errno == errno.EPIPE:
             pass
+        else:
+            raise
 
     sys.exit(0)
 


### PR DESCRIPTION
Right now in both https://github.com/trapexit/mergerfs-tools/blob/224c5c0cecdb4fe3783e4a52ace760553ee7d010/src/mergerfs.dedup#L526-L528 and https://github.com/trapexit/mergerfs-tools/blob/224c5c0cecdb4fe3783e4a52ace760553ee7d010/src/mergerfs.fsck#L205-L207, all `IOError`s are being caught and ignored even though the code suggests the intent is only to ignore `EPIPE`.

To see this, try the following with and without the `raise` line:

```python
import errno
try:
    raise IOError(errno.ENOENT, "ENOENT")
except IOError as e:
    if e.errno == errno.EPIPE:
        pass
    raise
```

I'm not sure of the actual intent but I'm opening a PR that reraises the error if it's not EPIPE.  That does change behavior, but mergerfs-tools should probably be explicit about what's being caught here or it may cause confusion.