### PR TITLE
Fix IndexError caused by no matches

### DIFF
--- a/src/mergerfs.balance
+++ b/src/mergerfs.balance
@@ -247,6 +247,8 @@ def main():
             todrive     = l[-1][0]
             relfilepath = None
             while not relfilepath:
+                if len(l) == 0 or len(l[0]) == 0:
+                    break
                 fromdrive = l[0][0]
                 del l[0]
                 relfilepath = find_a_file(fromdrive,
@@ -258,7 +260,7 @@ def main():
             if fromdrive == todrive:
                 break
             if relfilepath in seen:
-                break;
+                break
             seen.add(relfilepath)
 
             args = build_move_file(fromdrive,todrive,relfilepath)
@@ -266,7 +268,7 @@ def main():
             print_args(args)
             rv = execute(args)
             if rv:
-                break;
+                break
             l = freespace_percentage(srcmounts)
     except KeyboardInterrupt:
         print("exiting: CTRL-C pressed")


### PR DESCRIPTION
If you provide a limiting pattern that results in no files matching an `IndexError` happens instead of exiting cleanly:

```
$ mergerfs.balance -i '12341234' /media/bigdata
Traceback (most recent call last):
  File "/home/jolly/bin/mergerfs.balance", line 278, in <module>
    main()
  File "/home/jolly/bin/mergerfs.balance", line 250, in main
    fromdrive = l[0][0]
IndexError: list index out of range
```

Also removed some superfluous `;`