### PR TITLE
RFC/WIP: moving hard links along with file

### DIFF
--- a/src/mergerfs.balance
+++ b/src/mergerfs.balance
@@ -117,21 +117,39 @@ def execute(args):
     return subprocess.call(args)
 
 
+def execute_with_stdout(args):
+    result = subprocess.run(args, stdout=subprocess.PIPE)
+    return result.stdout.decode('utf-8')
+
+
 def print_args(args):
     quoted = [shlex.quote(arg) for arg in args]
     print(' '.join(quoted))
 
 
-def build_move_file(src,dst,relfile):
-    frompath = os.path.join(src,'./',relfile)
+def build_move_files(src,dst,relfiles):
     topath   = dst+'/'
     args = ['rsync',
             '-avlHAXWES',
             '--relative',
             '--progress',
-            '--remove-source-files',
-            frompath,
-            topath]
+            '--remove-source-files']
+
+    for f in relfiles:
+        args.append(os.path.join(src,'./',f))
+
+    args.append(topath)
+    return args
+
+def build_find_links(src,relfile):
+    filepath = os.path.join(src,relfile)
+    args = ['find',
+            src,
+            '-samefile',
+            filepath,
+            '-not',
+            '-path',
+            filepath]
     return args
 
 
@@ -261,8 +279,20 @@ def main():
                 break;
             seen.add(relfilepath)
 
-            args = build_move_file(fromdrive,todrive,relfilepath)
-            print('file: {}\nfrom: {}\nto:   {}'.format(relfilepath,fromdrive,todrive))
+            args = build_find_links(fromdrive,relfilepath)
+
+            relfilepaths = [relfilepath]
+            links = execute_with_stdout(args).splitlines()
+            if len(links) > 0:
+                for l in links:
+                    rel = os.path.relpath(l, fromdrive)
+                    relfilepaths.append(rel)
+
+            args = build_move_files(fromdrive,todrive,relfilepaths)
+
+            for f in relfilepaths:
+                print('file: '+f)
+            print('from: {}\nto:   {}'.format(fromdrive,todrive))
             print_args(args)
             rv = execute(args)
             if rv:


### PR DESCRIPTION
I wanted to open this PR to see if you would be willing to merge one that added support for moving hard links of a file along with a file via an option. If you are interested, I will work this PR into a fully featured one. I heavily use hard links for various file sorting and organization systems I have. As such, without this modification I can't use `mergerfs.balance` as it results in duplicates the files and breaks the link.

Proposed solution:
If you enable the links option, use gnu find to locate hard linked files using the `-samefile` argument. You have already enabled rsync hard link handling with the `-H` option, so all I had to do was pass the other hard linked files along with the "original" as src files in the rsync command and rsync handles the rest.

Questions/Complications:
1. Should the found hard links be subject to the various include and exclude options? I personally don't want the links filtered, but I could see a user expecting or wanting this. As such, maybe this should be configurable via an option?
2. If we do filter the hard links, what do we do when a found hard link is excluded? Simply excluding it would result in duplicating the file. This doesn't seem like the behavior a user who has already told the program to preserve hard links would want. The two options I think are to either exit with a message or modify `find_a_file()` to support skipping `seen` files.