### PR TITLE
balance, consolidate: prevent infinite recursion

### DIFF
--- a/src/mergerfs.balance
+++ b/src/mergerfs.balance
@@ -57,6 +57,8 @@ def ismergerfs(path):
 
 
 def mergerfs_control_file(basedir):
+    if basedir == '/':
+        return None
     ctrlfile = os.path.join(basedir,'.mergerfs')
     if os.path.exists(ctrlfile):
         return ctrlfile

--- a/src/mergerfs.consolidate
+++ b/src/mergerfs.consolidate
@@ -66,6 +66,8 @@ def ismergerfs(path):
 
 
 def mergerfs_control_file(basedir):
+    if basedir == '/':
+        return None
     ctrlfile = os.path.join(basedir,'.mergerfs')
     if os.path.exists(ctrlfile):
         return ctrlfile


### PR DESCRIPTION
The mergerfs_control_file() functions of mergerfs.balance and
mergerfs.consolidate will recurse infinitely (up to Python's recursion
limit) when given a path which does not contain a file named '.mergerfs'
in any of its parent directories. mergerfs.dup does not have this issue.
Update the megerfs_control_file() functions in the affected commands to
match the version in mergerfs.dup.

Fixes #60