### PR TITLE
ctl: ignore subpath bind-mounts to a mergerfs

### DIFF
--- a/src/mergerfs.ctl
+++ b/src/mergerfs.ctl
@@ -21,11 +21,14 @@ import sys
 
 def find_mergerfs():
     rv = []
-    with open('/proc/mounts','r') as f:
+    with open('/proc/self/mountinfo','r') as f:
         for line in f:
             values = line.split()
-            if values[2] == 'fuse.mergerfs':
-                rv.append(values[1])
+            mountroot, mountpoint = values[3:5]
+            separator = values.index('-', 6)
+            fstype = values[separator + 1]
+            if fstype == 'fuse.mergerfs' and mountroot == '/':
+                rv.append(mountpoint)
     return rv
 
 


### PR DESCRIPTION
mergerfs.ctl commands break when a subpath of a mergerfs filsystem is
bind-mounted to some path. For example, given a mergerfs mounted at
/mnt/mergerfs and the path /mnt/mergerfs/foo bind-mounted to /srv/foo,
the command 'mergerfs.ctl info' will produce output similar to the
following:

    - mount: /mnt/mergerfs
      version: 2.28.2
      pid: 704
      srcmounts:
        - /mnt/dev-disk-by-label-disk0
        - /mnt/dev-disk-by-label-disk1
    Traceback (most recent call last):
      File "/usr/local/bin/mergerfs.ctl", line 272, in <module>
        main()
      File "/usr/local/bin/mergerfs.ctl", line 264, in main
        args.func(fspaths,args)
      File "/usr/local/bin/mergerfs.ctl", line 243, in cmd_info
        print_mergerfs_info(fspaths)
      File "/usr/local/bin/mergerfs.ctl", line 97, in print_mergerfs_info
        version   = os.getxattr(ctrlfile,'user.mergerfs.version')
    FileNotFoundError: [Errno 2] No such file or directory: '/srv/foo/.mergerfs'

What's happening is that mergerfs.ctl assumes that all paths returned
from the find_mergerfs() function correspond to the root of a mergerfs
filesystem; that each path is a directory containing a mergerfs control
file. The find_mergerfs() function returns _all_ mount points to any
mergerfs, whether or not the root of the filesystem is mounted there.

Change the find_mergerfs() function to read the list of mounts from
/proc/self/mountinfo and to only return mergerfs mounts that are rooted
in the filesystem root.