### PR TITLE
mergerfs-tools: remove sparse option from rsync

### DIFF
--- a/src/mergerfs.balance
+++ b/src/mergerfs.balance
@@ -129,7 +129,7 @@ def build_move_file(src,dst,relfile):
     frompath = os.path.join(src,'./',relfile)
     topath   = dst+'/'
     args = ['rsync',
-            '-avlHAXWES',
+            '-avlHAXWE',
             '--relative',
             '--progress',
             '--remove-source-files',

--- a/src/mergerfs.consolidate
+++ b/src/mergerfs.consolidate
@@ -128,7 +128,7 @@ def build_move_file(src,tgt,rel):
     srcpath = os.path.join(src,'./',rel)
     tgtpath = tgt.rstrip('/') + '/'
     return ['rsync',
-            '-avHAXWES',
+            '-avHAXWE',
             '--numeric-ids',
             '--progress',
             '--relative',

--- a/src/mergerfs.dup
+++ b/src/mergerfs.dup
@@ -93,7 +93,7 @@ def build_copy_file(src,tgt,rel):
     srcpath = os.path.join(src,'./',rel)
     tgtpath = tgt + '/'
     return ['rsync',
-            '-avHAXWES',
+            '-avHAXWE',
             '--numeric-ids',
             '--progress',
             '--relative',


### PR DESCRIPTION
https://github.com/trapexit/mergerfs/issues/902#issuecomment-830928020

sparse with rsync issues 1KB w/r as opposed to 32KB r/w. XFS handles this a bit better than ZFS, but if you use the combination of the options on a FUSE mount (suchas mergerfs) you're in for a really bad time as throughput will plummet.

As such, dropping sparse results in a 31x reduction of context switches to copy the same amount of data, and more efficiently uses the disk.