### PR TITLE
Skip dup if srcfile cannot be found on any path

### DIFF
--- a/src/mergerfs.dup
+++ b/src/mergerfs.dup
@@ -343,6 +343,10 @@ def main():
                 relpath  = mergerfs_relpath(fullpath)
                 existing = mergerfs_all_basepaths(fullpath,relpath)
 
+                if not existing:
+                    printf("Missing %s on all paths" % relpath)
+                    continue
+
                 srcpath  = dupfun(basepath,relpath,existing)
                 srcfile  = os.path.join(srcpath,relpath)
                 srcfile_size = os.lstat(srcfile).st_size


### PR DESCRIPTION
When running mergerfs.dup on a mount that is actively being used and a file is modified or deleted during the dup run, it crashes.

This is a work-around for still running dup on all existing files, skipping the one it can't find on any of the source paths.